### PR TITLE
change to uniput to report events right away

### DIFF
--- a/drv_G15.c
+++ b/drv_G15.c
@@ -106,6 +106,13 @@ void drv_G15_keyDown(unsigned char scancode)
     event.code = scancode;
     event.value = 1;
     write(uinput_fd, &event, sizeof(event));
+	
+/* hopefully this makes the system report the keys */
+
+    event.type = EV_SYN;
+    event.code = SYN_REPORT;
+    event.value = 0;
+    write(uinput_fd, &event, sizeof(event));
 }
 
 void drv_G15_keyUp(unsigned char scancode)
@@ -115,6 +122,13 @@ void drv_G15_keyUp(unsigned char scancode)
 
     event.type = EV_KEY;
     event.code = scancode;
+    event.value = 0;
+    write(uinput_fd, &event, sizeof(event));
+	
+/* hopefully this makes the system report the keys */
+
+    event.type = EV_SYN;
+    event.code = SYN_REPORT;
     event.value = 0;
     write(uinput_fd, &event, sizeof(event));
 }


### PR DESCRIPTION
added code to report key events right away rather than reporting them after you pressed several keys.

I was getting key events in bunches of 4 all at once.